### PR TITLE
Fix resource failure due to query parameter

### DIFF
--- a/r2-streamer-swift/Server/PublicationServer.swift
+++ b/r2-streamer-swift/Server/PublicationServer.swift
@@ -227,6 +227,15 @@ public class PublicationServer: ResourcesServer {
 
             let resource = publication.get(href.removingPercentEncoding ?? href)
             let range = request.hasByteRange() ? request.byteRange : nil
+            
+            switch resource.length {
+            case .failure(_):
+                if let count = request.url.query?.count, count > 0, let link = publication.link(withHREF: href) {
+                    resource = publication.get(link)
+                }
+            default:
+                break
+            }
             return WebServerResourceResponse(
                 resource: resource,
                 range: range,


### PR DESCRIPTION
Added fallback in case of resource failure due to the query parameter in url.